### PR TITLE
Correct the apostrophe symbol

### DIFF
--- a/uniform/languages/fr.php
+++ b/uniform/languages/fr.php
@@ -6,18 +6,18 @@ l::set('uniform-fields-not-valid', 'Certains champs contiennent des données non
 
 l::set('uniform-email-subject', 'Message de la part du site internet');
 l::set('uniform-email-success', 'Merci, votre formulaire a bien été envoyé.');
-l::set('uniform-email-error', 'Une erreur s\'est produite lors de l\'envoi du formulaire :');
+l::set('uniform-email-error', 'Une erreur s’est produite lors de l’envoi du formulaire :');
 l::set('uniform-email-copy', 'Copie :');
 
 l::set('uniform-calc-plus', 'plus');
 
-l::set('uniform-log-success', 'L\'entrée dans le log a bien été créée.');
-l::set('uniform-log-error', 'Une erreur s\'est produite lors de l\'écriture dans le fichier de log.');
+l::set('uniform-log-success', 'L’entrée dans le log a bien été créée.');
+l::set('uniform-log-error', 'Une erreur s’est produite lors de l’écriture dans le fichier de log.');
 
 l::set('uniform-login-error', 'Identifiant ou mot de passe invalide.');
 l::set('uniform-login-success', 'Identification réussie.');
 
 l::set('uniform-webhook-success', 'Appel du webhook réussi.');
-l::set('uniform-webhook-error', 'Une erreur s\'est produite lors de l\'appel du webhook : ');
+l::set('uniform-webhook-error', 'Une erreur s’est produite lors de l’appel du webhook : ');
 
 l::set('uniform-email-select-error', 'Destinataire invalide.');


### PR DESCRIPTION
Replacing `'` by `’` in the french translation.