### PR TITLE
Issue #90 - passing 'params' action info through to the email template

### DIFF
--- a/uniform/actions/email.php
+++ b/uniform/actions/email.php
@@ -22,6 +22,7 @@ uniform::$actions['email'] = function ($form, $actionOptions) {
         'sender' => a::get($actionOptions, 'sender'),
         'service' => a::get($actionOptions, 'service', 'mail'),
         'service-options' => a::get($actionOptions, 'service-options', []),
+        'params' => a::get($actionOptions, 'params', []),
     ];
 
     // remove newlines to prevent malicious modifications of the email


### PR DESCRIPTION
It is obviously a very minor change and also quite unobtrusive. Just like in the webhook action, I am using the 'params' action option to keep things nice and consistent.