### PR TITLE
Update links in the docs to point to the Kirby2 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ If you have a single language site you can choose the language Uniform should us
 c::set('uniform.language', 'de');
 ```
 
-See [here](https://github.com/mzur/kirby-uniform/tree/master/languages) for all supported languages.
+See [here](https://github.com/mzur/kirby-uniform/tree/kirby-2/languages) for all supported languages.
 
-**Note:** [Disable the Kirby cache](https://getkirby.com/docs/developer-guide/advanced/caching#ignoring-pages) for pages where you use Uniform to make sure the form is generated dynamically.
+**Note:** [Disable the Kirby cache](https://k2.getkirby.com/docs/developer-guide/advanced/caching#ignoring-pages) for pages where you use Uniform to make sure the form is generated dynamically.
 
 ## Documentation
 

--- a/docs/actions/actions.md
+++ b/docs/actions/actions.md
@@ -84,4 +84,4 @@ There are two methods to conveniently retrieve options:
 - `option($key, $default = null)`: Returns an option from the options array or an optional default value. Example: `$this->option('field', self::FIELD_NAME)`
 - `requireOption($key)`: Returns an option from the options array or throws an exception of the option is not present. This can be used for mandatory options. Example: `$this->requireOption('file')`
 
-Take a look at the [built-in actions](https://github.com/mzur/kirby-uniform/tree/master/src/Actions) for some examples.
+Take a look at the [built-in actions](https://github.com/mzur/kirby-uniform/tree/kirby-2/src/Actions) for some examples.

--- a/docs/actions/email.md
+++ b/docs/actions/email.md
@@ -72,7 +72,7 @@ The subject of the email. By default the `uniform-email-subject` language variab
 
 Name of a snippet to use as email body. If this option is set the action will use the snippet for the email body instead of printing the `name: value` pairs as plain text. Inside the snippet you have access to the `$data` array, which is a plain associative array containing the form data, and the `$options` array which is the options array that you passed on to the email action.
 
-Check out the `email-*` snippets of the [Uniform repo](https://github.com/mzur/kirby-uniform/tree/master/snippets) for examples.
+Check out the `email-*` snippets of the [Uniform repo](https://github.com/mzur/kirby-uniform/tree/kirby-2/snippets) for examples.
 
 ### replyTo
 
@@ -80,11 +80,11 @@ Set a static email address as `replyTo` of the email instead of the value of the
 
 ### service
 
-Name of an [email service](https://getkirby.com/docs/developer-guide/advanced/emails) to use. The default service is `mail`. For other services, make sure to provide the [service-options](#service-options) option as well.
+Name of an [email service](https://k2.getkirby.com/docs/developer-guide/advanced/emails) to use. The default service is `mail`. For other services, make sure to provide the [service-options](#service-options) option as well.
 
 ### service-options
 
-An array of options to pass along to the email service. If you use the [SES service](https://getkirby.com/docs/developer-guide/advanced/emails#amazon-ses), for example, you need to provide the `key`, `secret` and `host` in this array. This will be the `$email->options` array you can access in a custom email service.
+An array of options to pass along to the email service. If you use the [SES service](https://k2.getkirby.com/docs/developer-guide/advanced/emails#amazon-ses), for example, you need to provide the `key`, `secret` and `host` in this array. This will be the `$email->options` array you can access in a custom email service.
 
 ### receive-copy
 

--- a/docs/examples/ajax.md
+++ b/docs/examples/ajax.md
@@ -1,6 +1,6 @@
 # AJAX Example
 
-This example shows how to submit a form and handle validation via AJAX. It uses a [route](https://getkirby.com/docs/developer-guide/advanced/routing) as endpoint for the form submission. The action of the route is similar to the page controller code you have seen in the other examples. This form is equivalent to the [basic example](basic).
+This example shows how to submit a form and handle validation via AJAX. It uses a [route](https://k2.getkirby.com/docs/developer-guide/advanced/routing) as endpoint for the form submission. The action of the route is similar to the page controller code you have seen in the other examples. This form is equivalent to the [basic example](basic).
 
 ## Route
 

--- a/docs/guards/guards.md
+++ b/docs/guards/guards.md
@@ -93,4 +93,4 @@ There are two methods to conveniently retrieve options:
 - `option($key, $default = null)`: Returns an option from the options array or an optional default value. Example: `$this->option('field', self::FIELD_NAME)`
 - `requireOption($key)`: Returns an option from the options array or throws an exception of the option is not present. This can be used for mandatory options. Example: `$this->requireOption('file')`
 
-Take a look at the [built-in guards](https://github.com/mzur/kirby-uniform/tree/master/src/Guards) for some examples.
+Take a look at the [built-in guards](https://github.com/mzur/kirby-uniform/tree/kirby-2/src/Guards) for some examples.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,10 +53,10 @@ If you have a single language site you can choose the language Uniform should us
 c::set('uniform.language', 'de');
 ```
 
-See [here](https://github.com/mzur/kirby-uniform/tree/master/languages) for all supported languages.
+See [here](https://github.com/mzur/kirby-uniform/tree/kirby-2/languages) for all supported languages.
 
 !!! warning "Note"
-    [Disable the Kirby cache](https://getkirby.com/docs/developer-guide/advanced/caching#ignoring-pages) for pages where you use Uniform to make sure the form is generated dynamically.
+    [Disable the Kirby cache](https://k2.getkirby.com/docs/developer-guide/advanced/caching#ignoring-pages) for pages where you use Uniform to make sure the form is generated dynamically.
 
 !!! warning "Note"
     Uniform makes use of Kirby sessions and the CSRF helper. This requires a session cookie to be set.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -173,7 +173,7 @@ There is no equivalent method to check this. The required validation is now hand
 
 ### token()
 
-Use the `csrf()` [helper function](https://getkirby.com/docs/cheatsheet/helpers/csrf) to get the token or the `csrf_field()` helper function to get a hidden form field with the token.
+Use the `csrf()` [helper function](https://k2.getkirby.com/docs/cheatsheet/helpers/csrf) to get the token or the `csrf_field()` helper function to get a hidden form field with the token.
 
 ### id()
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,7 +42,7 @@ If any of these steps fail, Uniform will immediately redirect back to the form p
 
 ## Validation rules
 
-The constructor argument of `Uniform\Form` is an array of validation rules and error messages for each form field. To validate the form data Kirby's [invalid helper function](https://getkirby.com/docs/cheatsheet/helpers/invalid) is used, so you can use all [validators](https://getkirby.com/docs/cheatsheet#validators) that are available for the invalid function (or [implement your own](https://getkirby.com/docs/developer-guide/objects/validators)). If the form field validation failed, the individual error messages can be fetched through the [error method](methods#errorkey) of the `$form` object.
+The constructor argument of `Uniform\Form` is an array of validation rules and error messages for each form field. To validate the form data Kirby's [invalid helper function](https://k2.getkirby.com/docs/cheatsheet/helpers/invalid) is used, so you can use all [validators](https://k2.getkirby.com/docs/cheatsheet#validators) that are available for the invalid function (or [implement your own](https://k2.getkirby.com/docs/developer-guide/objects/validators)). If the form field validation failed, the individual error messages can be fetched through the [error method](methods#errorkey) of the `$form` object.
 
 Besides validation rules and error messages, the constructor array also defines which form fields Uniform should use in the first place. If only `email` and `message` are defined but the form also has a `name` field, it will be ignored because it was not defined in the constructor array. You can define form fields that should not be included in the validation with an empty validation array like this:
 


### PR DESCRIPTION
When I browsed the ReadTheDocs documentation, I noticed that the official documentation links point into the void, since the Kirby2 docs were moved to the k2 subdomain.

- Change links to point to the k2 subdomain
- Change GitHub links to point to the kirby-2 branch