### PR TITLE
Add kirby namespace to fix composer loading issue

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kirby\Cms\App as Kirby;
+
 Kirby::plugin('mzur/kirby-uniform', [
     'templates' => [
         'uniform/log-json' => __DIR__.'/templates/log-json.php',


### PR DESCRIPTION
In the context of installing the [recaptcha guard plugin](https://github.com/eXpl0it3r/kirby-uniform-recaptcha) I have an issue that the Kirby class alias could not be found. I think this based on the wrong order of the composer autoloading.

In the following issue I added more details: https://github.com/eXpl0it3r/kirby-uniform-recaptcha/issues/3

The PR adds the Kirby namespace to the config.php. In my case it solves the issue and composer could generate the autoloading in the right order.

The fix should not affect anything and give composer setups more context.