### PR TITLE
Correct file location for custom guard "quick plugin".

### DIFF
--- a/docs/guards/guards.md
+++ b/docs/guards/guards.md
@@ -55,7 +55,7 @@ Although you probably want to use magic methods in most cases, it might be usefu
 
 ## Custom Guards
 
-As you have seen in the previous section, each guard is a class in the `Uniform\Guards` namespace. To write your own guards you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin. The plugin may be a file `site/plugins/uniform-guards.php` that will be automatically loaded by Kirby.
+As you have seen in the previous section, each guard is a class in the `Uniform\Guards` namespace. To write your own guards you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin. The plugin may be a file `site/plugins/uniform-guards/index.php` that will be automatically loaded by Kirby.
 
 Let's take a look at the implementation of a bare bones custom guard:
 


### PR DESCRIPTION
I have no idea if this is a leftover from K2, but K3 doesn't load `site/plugins/xxx.php` anymore. It does load `site/plugins/xxx/index.php` automatically though, so…