### PR TITLE
Update readme for actions and guards

### DIFF
--- a/docs/actions/actions.md
+++ b/docs/actions/actions.md
@@ -44,9 +44,9 @@ if (kirby()->request()->is('POST')) {
 
 ## Custom Actions
 
-Custom actions are very similar to [custom guards](/guards/guards#custom-guards), too. Each action is a class in the `Uniform\Actions` namespace. To write your own actions you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin. The plugin may be a file `site/plugins/uniform-actions/index.php` that will be automatically loaded by Kirby.
+Custom actions are very similar to [custom guards](/guards/guards#custom-guards), too. Each action is a class in the `Uniform\Actions` namespace. To write your own actions you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin.
 
-Let's take a look at the implementation of an exemplary MyCustomAction:
+Let's take a look at the implementation of an exemplary MyCustomAction, defined in the `site/plugins/uniform-custom-actions/MyCustomAction.php` file:
 
 ```php
 <?php
@@ -58,13 +58,34 @@ class MyCustomAction extends Action
     public function perform()
     {
         try {
-            var_dump($this->form->data());
+            // get the name of the session variable
+            $name = $this->option('name', 'session-store');
+
+            // put a custom value into session
+            Kirby::instance()->session()->set($name, date('H:i:s'));
+
+            // also return the value - if you want to capture it
+            // back in controller for further modification
+            return date('H:i:s');
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
     }
 }
+```
 
+And the complementary `site/plugins/uniform-custom-actions/index.php` to be loaded automatically by Kirby:
+
+```php
+<?php
+
+use Kirby\Cms\App as Kirby;
+
+load([
+    'Uniform\\Actions\\MyCustomAction' => 'MyCustomAction.php'
+], __DIR__);
+
+Kirby::plugin('yourname/uniform-custom-actions', []);
 ```
 
 As you can see we also place the class in the `Uniform\Actions` namespace and give it a name with the suffix `Action`. You don't have to do this but it is a requirement if you want to call the action through a magic method (`$form->myCustomAction()`). Also, it makes extending the `Uniform\Actions\Action` base class easier, which you have to do for all actions.

--- a/docs/actions/actions.md
+++ b/docs/actions/actions.md
@@ -58,15 +58,7 @@ class MyCustomAction extends Action
     public function perform()
     {
         try {
-            // get the name of the session variable
-            $name = $this->option('name', 'session-store');
-
-            // put a custom value into session
-            Kirby::instance()->session()->set($name, date('H:i:s'));
-
-            // also return the value - if you want to capture it
-            // back in controller for further modification
-            return date('H:i:s');
+            var_dump($this->form->data());
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
@@ -74,18 +66,14 @@ class MyCustomAction extends Action
 }
 ```
 
-And the complementary `site/plugins/uniform-custom-actions/index.php` to be loaded automatically by Kirby:
+And the complementary `site/plugins/uniform-custom-actions/index.php` to be loaded automatically by Kirby (not required if the action is autoloaded by Composer):
 
 ```php
 <?php
 
-use Kirby\Cms\App as Kirby;
-
 load([
     'Uniform\\Actions\\MyCustomAction' => 'MyCustomAction.php'
 ], __DIR__);
-
-Kirby::plugin('yourname/uniform-custom-actions', []);
 ```
 
 As you can see we also place the class in the `Uniform\Actions` namespace and give it a name with the suffix `Action`. You don't have to do this but it is a requirement if you want to call the action through a magic method (`$form->myCustomAction()`). Also, it makes extending the `Uniform\Actions\Action` base class easier, which you have to do for all actions.

--- a/docs/actions/actions.md
+++ b/docs/actions/actions.md
@@ -44,16 +44,16 @@ if (kirby()->request()->is('POST')) {
 
 ## Custom Actions
 
-Custom actions are very similar to [custom guards](/guards/guards#custom-guards), too. Each action is a class in the `Uniform\Actions` namespace. To write your own actions you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin. The plugin may be a file `site/plugins/uniform-actions.php` that will be automatically loaded by Kirby.
+Custom actions are very similar to [custom guards](/guards/guards#custom-guards), too. Each action is a class in the `Uniform\Actions` namespace. To write your own actions you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin. The plugin may be a file `site/plugins/uniform-actions/index.php` that will be automatically loaded by Kirby.
 
-Let's take a look at the implementation of an exemplary DumpAction:
+Let's take a look at the implementation of an exemplary MyCustomAction:
 
 ```php
 <?php
 
 namespace Uniform\Actions;
 
-class DumpAction extends Action
+class MyCustomAction extends Action
 {
     public function perform()
     {
@@ -67,7 +67,7 @@ class DumpAction extends Action
 
 ```
 
-As you can see we also place the class in the `Uniform\Actions` namespace and give it a name with the suffix `Action`. You don't have to do this but it is a requirement if you want to call the action through a magic method (`$form->dumpAction()`). Also, it makes extending the `Uniform\Actions\Action` base class easier, which you have to do for all actions.
+As you can see we also place the class in the `Uniform\Actions` namespace and give it a name with the suffix `Action`. You don't have to do this but it is a requirement if you want to call the action through a magic method (`$form->myCustomAction()`). Also, it makes extending the `Uniform\Actions\Action` base class easier, which you have to do for all actions.
 
 Each action must implement a `perform` method. In the method you do something with the form data. In case anything fails you can call the `fail` method. If an action fails the form will immediately redirect the request and display the form with an error message. The `fail` method takes two optional arguments:
 

--- a/docs/guards/guards.md
+++ b/docs/guards/guards.md
@@ -55,7 +55,7 @@ Although you probably want to use magic methods in most cases, it might be usefu
 
 ## Custom Guards
 
-As you have seen in the previous section, each guard is a class in the `Uniform\Guards` namespace. To write your own guards you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin. The plugin may be a file `site/plugins/uniform-guards.php` that will be automatically loaded by Kirby.
+As you have seen in the previous section, each guard is a class in the `Uniform\Guards` namespace. To write your own guards you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin. The plugin may be a file `site/plugins/custom-guards/index.php` that will be automatically loaded by Kirby.
 
 Let's take a look at the implementation of a bare bones custom guard:
 

--- a/docs/guards/guards.md
+++ b/docs/guards/guards.md
@@ -57,7 +57,7 @@ Although you probably want to use magic methods in most cases, it might be usefu
 
 As you have seen in the previous section, each guard is a class in the `Uniform\Guards` namespace. To write your own guards you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin. The plugin may be a file `site/plugins/custom-guards/index.php` that will be automatically loaded by Kirby.
 
-Let's take a look at the implementation of a bare bones custom guard:
+Let's take a look at the implementation of a bare bones custom guard, defined in the `site/plugins/uniform-custom-guards/MyCustomGuard.php` file:
 
 ```php
 <?php
@@ -74,6 +74,20 @@ class MyCustomGuard extends Guard
         }
     }
 }
+```
+
+And the complementary `site/plugins/uniform-custom-guards/index.php` to be loaded automatically by Kirby:
+
+```php
+<?php
+
+use Kirby\Cms\App as Kirby;
+
+load([
+    'Uniform\\Actions\\MyCustomGuard' => 'MyCustomGuard.php'
+], __DIR__);
+
+Kirby::plugin('yourname/uniform-custom-guards', []);
 ```
 
 As you can see we also place the class in the `Uniform\Guards` namespace and give it a name with the suffix `Guard`. You don't have to do this but it is a requirement if you want to call the guard through a magic method (`$form->myCustomGuard()`). Also, it makes extending the `Uniform\Guards\Guard` base class easier, which you have to do for all guards.

--- a/docs/guards/guards.md
+++ b/docs/guards/guards.md
@@ -55,7 +55,7 @@ Although you probably want to use magic methods in most cases, it might be usefu
 
 ## Custom Guards
 
-As you have seen in the previous section, each guard is a class in the `Uniform\Guards` namespace. To write your own guards you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin. The plugin may be a file `site/plugins/custom-guards/index.php` that will be automatically loaded by Kirby.
+As you have seen in the previous section, each guard is a class in the `Uniform\Guards` namespace. To write your own guards you can either provide them through a PHP package and Composer or implement them in the traditional way as a Kirby plugin.
 
 Let's take a look at the implementation of a bare bones custom guard, defined in the `site/plugins/uniform-custom-guards/MyCustomGuard.php` file:
 

--- a/docs/guards/guards.md
+++ b/docs/guards/guards.md
@@ -76,18 +76,14 @@ class MyCustomGuard extends Guard
 }
 ```
 
-And the complementary `site/plugins/uniform-custom-guards/index.php` to be loaded automatically by Kirby:
+And the complementary `site/plugins/uniform-custom-guards/index.php` to be loaded automatically by Kirby (not required if the guard is autoloaded by Composer):
 
 ```php
 <?php
 
-use Kirby\Cms\App as Kirby;
-
 load([
     'Uniform\\Actions\\MyCustomGuard' => 'MyCustomGuard.php'
 ], __DIR__);
-
-Kirby::plugin('yourname/uniform-custom-guards', []);
 ```
 
 As you can see we also place the class in the `Uniform\Guards` namespace and give it a name with the suffix `Guard`. You don't have to do this but it is a requirement if you want to call the guard through a magic method (`$form->myCustomGuard()`). Also, it makes extending the `Uniform\Guards\Guard` base class easier, which you have to do for all guards.


### PR DESCRIPTION
So, I updated the readme. Additionally, there's a repo at [adamkiss/kirby-uniform-demonstration](https://github.com/adamkiss/kirby-uniform-demonstration) with a demonstration of a clean 3.5.7.1 starterkit with uniform, custom guard and a custom actions.

I've seen the note in the #214 to make it AJAX compatible, but I've tried to do it with "default Javascript" and haven't gotten anywhere - I think it's highly dependent on:

1. what you're actually trying to achieve (content representations/routes/etc.)
2. your build process, your workflow and what libraries you use (and how you use them).

So that's not part of this PR.

---

The uniform demonstration repo will stay alive, so you can link it if you want, or we can transfer it to you, or I can give you access and you can try adding the XHR submission.