### PR TITLE
Feature: Add two getters to get created files / dirs

### DIFF
--- a/src/Actions/UploadAction.php
+++ b/src/Actions/UploadAction.php
@@ -129,4 +129,20 @@ class UploadAction extends Action
 
         return "{$prefix}_{$name}";
     }
+
+    /**
+     * @return array
+     */
+    public function getCreatedDirectories()
+    {
+        return $this->createdDirectories;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCreatedFiles()
+    {
+        return $this->createdFiles;
+    }
 }


### PR DESCRIPTION
I was using the UploadAction in Uniform to upload files. This is working great! The only issue I have right now is that I don't know what the created files / dirs are after the uploadaction. So for example:

```php
        $uploadAction = new UploadAction($form, ['fields' => [
            'passport_photograph' => [
                'target' => kirby()->roots()->content().'/photographer-passports',
                'prefix' => null,
            ],
        ]]);

        $form
            ->guard(RecaptchaGuard::class, ['secretKey' => $_ENV['CAPTCHA_SECRET_KEY']])
            ->action($uploadAction)
        ;
```

Because I'm using `prefix: null` the action generates an random string. I really would like to know `after` the action what this random string is in order to save it. There's no getter in the UploadAction right now, so I'm doing this PR :-)