### PR TITLE
Update doc to reflect version bump to 5.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Builtin actions:
 
 ## Installation
 
-Install Uniform via Composer: `composer require mzur/kirby-uniform:^4.0`
+Install Uniform via Composer: `composer require mzur/kirby-uniform:^5.0`
 
 Or [download](https://github.com/mzur/kirby-uniform/archive/master.zip) the repository and extract it to `site/plugins/uniform`.
 


### PR DESCRIPTION
The docs haven't been updated to reflect that version 5.x is the current version of this plugin. I've run into this twice now when adding uniform to a Kirby instance that uses a current version of Kirby itself. Since 4.x will actually not work with newer Kirby versions.