### PR TITLE
Fix .gitignore for vendor/mzur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ composer.lock
 # files of Composer dependencies that are not needed for the plugin
 vendor/*
 !vendor/composer
-!vendor/mzur/kirby-form
-!vendor/mzur/kirby-flash
+!vendor/mzur
 !vendor/autoload.php

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ composer.lock
 vendor/*
 !vendor/composer
 !vendor/mzur
+vendor/mzur/*
+!vendor/mzur/kirby-form
+!vendor/mzur/kirby-flash
 !vendor/autoload.php


### PR DESCRIPTION
I noticed the plugin breaks Kirby installations when deployed via Git, because the `.gitignore` is not correct.

You ignore every folder in vendor with `vendor/*`, adding exceptions for `mzur/kirby-form` and `mzur/kirby-flash`. Sounds about right at first glance, but since the `mzur` folder does not exist, these exceptions don't work. With those folders missing, the whole Kirby installation breaks with the following error:

```
Failed opening required '/site/plugins/kirby-uniform/vendor/composer/../mzur/kirby-flash/src/helpers.php'
```

This PR fixes the deployment by adding an exception for the whole `mzur` folder.