### PR TITLE
Allow body in email action

### DIFF
--- a/src/Actions/EmailAction.php
+++ b/src/Actions/EmailAction.php
@@ -3,7 +3,6 @@
 namespace Uniform\Actions;
 
 use Exception;
-use Uniform\Form;
 use Kirby\Cms\App;
 use Kirby\Toolkit\Str;
 use Kirby\Toolkit\I18n;
@@ -100,12 +99,13 @@ class EmailAction extends Action
     }
 
     /**
-     * Get the email subject and resolve possible template strings
-     *
+     * Resolve template strings
+     * 
+     * @param string $string
+     * 
      * @return string
      */
-    protected function getSubject()
-    {
+    protected function resolveTemplate($string) {
         // the form could contain arrays which are incompatible with the template function
         $templatableItems = array_filter($this->form->data(), function ($item) {
             return is_scalar($item);
@@ -119,14 +119,24 @@ class EmailAction extends Action
             $fallback = '';
         }
 
-        $subject = Str::template($this->option('subject', I18n::translate('uniform-email-subject')), $templatableItems, $fallback);
+        return  Str::template($string, $templatableItems, $fallback);
+    }
+
+    /**
+     * Get the email subject and resolve possible template strings
+     *
+     * @return string
+     */
+    protected function getSubject()
+    {
+        $subject = $this->resolveTemplate($this->option('subject', I18n::translate('uniform-email-subject')));
 
         // Remove newlines to prevent malicious modifications of the email header.
         return str_replace("\n", '', $subject);
     }
 
     /**
-     * Get the email body
+     * Get the email body and resolve possible template strings
      *
      * @param array $data
      *
@@ -136,6 +146,11 @@ class EmailAction extends Action
     {
         unset($data[self::EMAIL_KEY]);
         unset($data[self::RECEIVE_COPY_KEY]);
+
+        if (isset($data['body'])) {
+            return $this->resolveTemplate($data['body']);
+        }
+
         $body = '';
         foreach ($data as $key => $value) {
             if (is_array($value)) {

--- a/src/Actions/EmailAction.php
+++ b/src/Actions/EmailAction.php
@@ -55,6 +55,8 @@ class EmailAction extends Action
                 '_data' => $params['data'],
                 '_options' => $this->options,
             ]);
+        } else if (isset($params['body']) && is_string($params['body'])) {
+            $params['body'] = $this->resolveTemplate($params['body']);
         } else {
             $params['body'] = $this->getBody($this->form->data('', '', $escape));
         }
@@ -130,13 +132,13 @@ class EmailAction extends Action
     protected function getSubject()
     {
         $subject = $this->resolveTemplate($this->option('subject', I18n::translate('uniform-email-subject')));
-
+        
         // Remove newlines to prevent malicious modifications of the email header.
         return str_replace("\n", '', $subject);
     }
 
     /**
-     * Get the email body and resolve possible template strings
+     * Get the email body
      *
      * @param array $data
      *
@@ -146,10 +148,6 @@ class EmailAction extends Action
     {
         unset($data[self::EMAIL_KEY]);
         unset($data[self::RECEIVE_COPY_KEY]);
-
-        if (isset($data['body'])) {
-            return $this->resolveTemplate($data['body']);
-        }
 
         $body = '';
         foreach ($data as $key => $value) {

--- a/tests/Actions/EmailActionTest.php
+++ b/tests/Actions/EmailActionTest.php
@@ -127,6 +127,20 @@ class EmailActionTest extends TestCase
         $this->assertEquals($expect, $action->email->body()->text());
     }
 
+    public function testBodyTemplate()
+    {
+        $this->form->data('email', 'joe@user.com');
+        $this->form->data('name', 'Joe');
+        $this->form->data('data', ['somedata']);
+        $action = new EmailActionStub($this->form, [
+            'to' => 'jane@user.com',
+            'from' => 'info@user.com',
+            'body' => "Hello\n{{name}} with {{data}}"
+        ]);
+        $action->perform();
+        $this->assertEquals("Hello\nJoe with ", $action->email->body()->text());
+    }
+
     public function testBodyEscapeHtml()
     {
         $this->form->data('email', 'joe@user.com');


### PR DESCRIPTION
To be consistent with kirby's email function, a custom body is only used if no template is specified.
#242 