### PR TITLE
Fix EmailSelect action cleaning of 'recipient'

### DIFF
--- a/src/Actions/EmailSelectAction.php
+++ b/src/Actions/EmailSelectAction.php
@@ -22,7 +22,7 @@ class EmailSelectAction extends EmailAction
     public function perform()
     {
         $this->options['to'] = $this->getRecipient();
-        unset($this->data[self::RECIPIENT_FIELD]);
+        $this->form->forget(self::RECIPIENT_FIELD);
         unset($this->options['allowed-recipients']);
 
         return parent::perform();

--- a/tests/Actions/EmailSelectActionTest.php
+++ b/tests/Actions/EmailSelectActionTest.php
@@ -36,7 +36,7 @@ class EmailSelectActionTest extends TestCase
         ]);
         $action->perform();
         $this->assertEquals('jane@user.com', $action->params['to']);
-        $this->assertFalse(array_key_exists('recipient', $action->params));
+        $this->assertArrayNotHasKey('recipient', $action->params['data']);
     }
 
     public function testRecipientNotAllowed()


### PR DESCRIPTION
The EmailSelect action did not remove the 'recipient' field from the form data.

Resolves #245