### PR TITLE
Support `preset` parameter in email action

### DIFF
--- a/docs/actions/email.md
+++ b/docs/actions/email.md
@@ -52,6 +52,7 @@ return function ($kirby)
 
 The email action accepts the same options than the [email function of Kirby](https://getkirby.com/docs/guide/emails). You can pass on options like `cc`, `bcc` or even `attachments`. The `body` is ignored, however, as it is dynamically generated based on the form data. Here are some special options:
 
+
 ### to (required)
 
 The email address that should be the receiver of the emails. It can be dynamically chosen based on the form content with the [EmailSelectAction](email-select).
@@ -59,6 +60,9 @@ The email address that should be the receiver of the emails. It can be dynamical
 ### from (required)
 
 The email address that will be the sender of the emails. This should be some address that is associated with the website. If you host it at `example.com` the address may be `info@example.com`.
+
+### preset
+The [Kirby email preset](https://getkirby.com/docs/guide/emails#email-presets) to use as a template. It works exactly like you pass in an preset to Kirbys own email function. Uniform uses the preset values as base and merges the action parameters with them. If you have `to` and `from` defined in your preset you do not have to pass them in as parameters again.
 
 ### subject
 

--- a/src/Actions/EmailAction.php
+++ b/src/Actions/EmailAction.php
@@ -97,7 +97,7 @@ class EmailAction extends Action
      */
     protected function sendEmail(array $params)
     {
-        App::instance()->email($params);
+        App::instance()->email($params['preset'] ?? [], $params);
     }
 
     /**

--- a/src/Actions/EmailAction.php
+++ b/src/Actions/EmailAction.php
@@ -32,7 +32,7 @@ class EmailAction extends Action
      */
     public function perform()
     {
-        $this->options = $this->preset($this->options['preset'] ?? null);
+        $this->options = $this->preset($this->option('preset'));
 
         $params = array_merge($this->options, [
             'to' => $this->requireOption('to'),

--- a/src/Actions/EmailAction.php
+++ b/src/Actions/EmailAction.php
@@ -4,6 +4,7 @@ namespace Uniform\Actions;
 
 use Exception;
 use Kirby\Cms\App;
+use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Str;
 use Kirby\Toolkit\I18n;
 
@@ -31,6 +32,8 @@ class EmailAction extends Action
      */
     public function perform()
     {
+        $this->options = $this->preset($this->options['preset'] ?? null);
+
         $params = array_merge($this->options, [
             'to' => $this->requireOption('to'),
             'from' => $this->requireOption('from'),
@@ -97,7 +100,7 @@ class EmailAction extends Action
      */
     protected function sendEmail(array $params)
     {
-        App::instance()->email($params['preset'] ?? [], $params);
+        App::instance()->email([], $params);
     }
 
     /**
@@ -174,5 +177,30 @@ class EmailAction extends Action
     {
         return $this->option('receive-copy') === true
             && $this->form->data(self::RECEIVE_COPY_KEY);
+    }
+
+    /**
+     * Loads more options from Kirby email presets, if `preset` was set
+     *
+     * @return array
+     */
+    private function preset(string|null $preset): array
+    {
+        if (!$preset) {
+            return $this->options;
+        }
+
+        if (($presetOptions = App::instance()->option('email.presets.' . $preset)) === null) {
+            throw new NotFoundException([
+                'key' => 'email.preset.notFound',
+                'data' => ['name' => $preset],
+            ]);
+        }
+
+        // Options passed to the action always superseed preset options
+        $options = array_merge($presetOptions, $this->options);
+        unset($options['preset']);
+
+        return $options;
     }
 }


### PR DESCRIPTION
Hi all, 

thanks for this wonderful plugin. I have a minor thing that bugs me for a long time already: 

We have a `default` email preset in all our projects, that removes the `X-Mailer` header to not expose the PHPMailer version. 

We use your plugin to handle all our forms. Everytime we call the `emailAction`, we have to repeat the `default` email preset settings:

```php
->emailAction([
    // […] All other email action related settings removed for brevity
    'beforeSend' => function ($mailer) {
        $mailer->XMailer = ' ';
    },
])
```

This PR adds the possibility to just pass along a `preset` parameter:

```php
->emailAction([
    // […] All other email action related settings removed for brevity
    'preset' => 'default'
])
```

This way, the desired preset is just passed along to the Kirby email method and handled accordingly. 

Would love to see that merged, because you can also globally define even more parameters like default `sender` and `reply-to` addresses and what not.

Thanks and cheers