### PR TITLE
Require getkirby/composer-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "docs": "http://kirby-uniform.readthedocs.io"
     },
     "require": {
-        "mzur/kirby-form": "^3.0"
+        "mzur/kirby-form": "^3.0",
+        "getkirby/composer-installer": "^1.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Fixes #254 

You must require the Composer installer, which takes care of actually moving the folder to `site/plugins`. It also deletes the `vendor` folder checked into your repository. 

See https://getkirby.com/docs/guide/plugins/plugin-setup-basic#the-composer-json