### PR TITLE
Uniform Hooks

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -222,6 +222,7 @@ class Form extends BaseForm
     /**
      * Register a hook
      *
+     * @throws Exception If the hook event does not exist
      *
      * @param  string   $hook   Hook event
      * @param  callable $callback Hook callback


### PR DESCRIPTION
This is a work in progress of allowing to call hooks on various events; So far, I've added the hooks, and events of "error", "success" and "always", called in the `done()` function.

There are no tests yet, but I will add them if/when we iron out naming/existence of this feature and its parts.