### PR TITLE
Accessibility consideration for honeypot fields

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -20,7 +20,7 @@ if (!function_exists('honeypot_field')) {
     {
         $name = $name ?: HoneypotGuard::FIELD_NAME;
         $class = $class ?: 'uniform__potty';
-        return '<input type="text" name="'.$name.'" class="'.$class.'" tabindex="-1" autocomplete="off">';
+        return '<input type="text" name="'.$name.'" class="'.$class.'" tabindex="-1" aria-hidden="true" autocomplete="off">';
     }
 }
 


### PR DESCRIPTION
Quoting feature request on a similar Wordpress form helper:

> Include the aria-hidden="true" attribute on the <label> element to hide the honeypot from assistive technologies

— [Add labels to honeypot inputs for accessibility](https://wordpress.org/support/topic/add-to-honeypot-inputs-for-accessibility/#post-17278587)

While it's possibly dangerous to add more markup to honeypot fields, using a screen reader should still enable you to submit forms.