### PR TITLE
Sanitise filenames in UploadAction

### DIFF
--- a/src/Actions/UploadAction.php
+++ b/src/Actions/UploadAction.php
@@ -3,6 +3,7 @@
 namespace Uniform\Actions;
 
 use Kirby\Toolkit\A;
+use Kirby\Filesystem\F;
 use Kirby\Toolkit\I18n;
 
 /*
@@ -69,7 +70,7 @@ class UploadAction extends Action
             }
         }
 
-        $name = $file['name'];
+		$name = F::safeName($file['name']);
         $prefix = A::get($options, 'prefix');
 
         if (is_null($prefix)) {

--- a/tests/Actions/UploadActionTest.php
+++ b/tests/Actions/UploadActionTest.php
@@ -116,11 +116,14 @@ class UploadActionTest extends TestCase
             'testfield' => ['target' => $path, 'prefix' => false],
         ]]);
 
-        $action->perform();
+        try {
+            $action->perform();
+        } finally {
+            @unlink("{$path}/test-file.txt");
+            @rmdir($path);
+        }
+        
         $this->assertStringEndsWith('test-file.txt', $action->target);
-
-        @unlink("{$path}/test-file.txt");
-        @rmdir($path);
     }
 
     public function testHandleRollback()

--- a/tests/Actions/UploadActionTest.php
+++ b/tests/Actions/UploadActionTest.php
@@ -9,6 +9,10 @@ use Uniform\Exceptions\PerformerException;
 
 class UploadActionTest extends TestCase
 {
+
+    protected $dir;
+    protected $form;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -97,6 +101,26 @@ class UploadActionTest extends TestCase
             unlink("{$path}/prefixmyfile.txt");
             rmdir($path);
         }
+    }
+
+    public function testSanitizeFilename()
+    {
+        $path = $this->dir.'/uniform_abc123';
+        @mkdir($path);
+        $this->form->data('testfield', [
+            'name' => 'test+file.txt',
+            'tmp_name' => $this->dir.'/uniform_tmp',
+            'error' => UPLOAD_ERR_OK,
+        ]);
+        $action = new UploadActionStub($this->form, ['fields' => [
+            'testfield' => ['target' => $path, 'prefix' => false],
+        ]]);
+
+        $action->perform();
+        $this->assertStringEndsWith('test-file.txt', $action->target);
+
+        @unlink("{$path}/test-file.txt");
+        @rmdir($path);
     }
 
     public function testHandleRollback()


### PR DESCRIPTION
Fixes filenames with special characters (like `+`) that break the Panel by using Kirby's `F::safeName()` method, consistent with how Kirby handles uploads in the Panel itself.

Closes https://github.com/mzur/kirby-uniform/issues/272.